### PR TITLE
Number of photons and positrons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,10 +31,15 @@
 *.out
 *.app
 
-#Build folder
+# Build folder
 build/
 simulation/build/
 .idea/
 simulation/.idea/
 cmake-build-debug/
 simulation/cmake-build-debug/
+
+# Utils folder
+*.png
+*.root
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DarkPhoton-LNLS
 
-## Detector simulation for search o Dark Photon in beam-dump experiment
+## Detector simulation for search of Dark Photon in beam-dump experiment
 
 This project is a simplified simulation of the PADME experiment at INFN LNF using Geant4
 
@@ -24,4 +24,8 @@ Users must have at least Geant4 version 11 installed.
 5. Finally, to start the simulation, you can run 
    ```
    ./main
+   ```
+   Alternatively, it is possible to run a macro file that runs 100000 events with no GUI. The data is stored in a ROOT file.
+   ```
+   ./main run.mac
    ```

--- a/simulation/DetectorConstruction.cc
+++ b/simulation/DetectorConstruction.cc
@@ -1,6 +1,5 @@
 #include "DetectorConstruction.hh"
 
-
 G4VPhysicalVolume *MyDetectorConstruction::Construct()
 {
     G4NistManager *nist = G4NistManager::Instance();
@@ -76,39 +75,33 @@ G4VPhysicalVolume *MyDetectorConstruction::Construct()
 
     G4Material *diamond = new G4Material("diamond", 3.515*g/cm3, 1);
     diamond->AddElement(nist->FindOrBuildElement("C"), 1);
-
     G4Box *solidDiamondTarget = new G4Box("solidDiamondTarget", 2*cm, 2*cm, 0.0001*m);
-
     G4LogicalVolume *logicalDiamondTarget = new G4LogicalVolume(solidDiamondTarget, diamond, "logicalDiamondTarget");
-
     G4VPhysicalVolume *physDiamond = new G4PVPlacement(0, G4ThreeVector(0., 0., -3.2*m), logicalDiamondTarget, "physDiamond", logicWorld, false, 0, true);
 
     // Photon detector:
 
     G4Box *calorimeterS = new G4Box("Calorimeter", boxWidth, boxWidth, 0.01*m);
-
     calorimeterLV = new G4LogicalVolume(calorimeterS, BGO, "CalorimeterLV");
-
-    G4VPhysicalVolume *physDetector = new G4PVPlacement(0, G4ThreeVector(0, 0, 3.01*m), calorimeterLV, "Calorimeter", logicWorld, false, 0, true);
+    G4VPhysicalVolume *physDetector = new G4PVPlacement(0, G4ThreeVector(0, 0, 3.10*m), calorimeterLV, "Calorimeter", logicWorld, false, 0, true);
 
     // Positron detector:
 
     G4Box *positronDetectorS = new G4Box("PositronDetector", boxWidth, 0.5*m, 0.01*m);
-
     positronDetectorLV = new G4LogicalVolume(positronDetectorS, vacuum, "PositronDetectorLV");
-
     auto detectorRot = new G4RotationMatrix();
     detectorRot->rotateX(-33.69*deg);
-
     G4VPhysicalVolume *physDetector2 = new G4PVPlacement(detectorRot, G4ThreeVector(0, -1.35*m, 2.35*m), positronDetectorLV, "PositronDetector", logicWorld, false, 0, true);
 
-    // Fake detector:
+    // Fake detectors:
 
-    G4Box *fakeDetectorS = new G4Box("FakeDetector", boxWidth, 0.5*m, 0.01*m);
+    G4Box *fakeCaloDetectorS = new G4Box("FakeCaloDetector", boxWidth, boxWidth, 0.01*m);
+    fakeCaloDetectorLV = new G4LogicalVolume(fakeCaloDetectorS, vacuum, "FakeCaloDetectorLV");
+    G4VPhysicalVolume *physFakeCaloDetector = new G4PVPlacement(0, G4ThreeVector(0, 0, 3.01*m), fakeCaloDetectorLV, "FakeCaloDetector", logicWorld, false, 0, true);
 
-    fakeDetectorLV = new G4LogicalVolume(fakeDetectorS, vacuum, "FakeDetectorLV");
-
-    G4VPhysicalVolume *physFakeDetector = new G4PVPlacement(detectorRot, G4ThreeVector(0, -1.25*m, 2.21*m), fakeDetectorLV, "FakeDetector", logicWorld, false, 0, true);
+    G4Box *fakePosDetectorS = new G4Box("FakePosDetector", boxWidth, 0.5*m, 0.01*m);
+    fakePosDetectorLV = new G4LogicalVolume(fakePosDetectorS, vacuum, "FakePosDetectorLV");
+    G4VPhysicalVolume *physFakePosDetector = new G4PVPlacement(detectorRot, G4ThreeVector(0, -1.25*m, 2.21*m), fakePosDetectorLV, "FakePosDetector", logicWorld, false, 0, true);
 
     // Visualization attributes:
 
@@ -133,12 +126,20 @@ G4VPhysicalVolume *MyDetectorConstruction::Construct()
 
 void MyDetectorConstruction::ConstructSDandField()
 {
-    if (G4SDManager::GetSDMpointer()->FindSensitiveDetector("Detector",0)) delete G4SDManager::GetSDMpointer()->FindSensitiveDetector("Detector");
-    G4SDManager* sdMan = G4SDManager::GetSDMpointer();
-    MyPositronDetector* sd = new MyPositronDetector("Detector", "DetectorCollection", this);
-    sdMan->AddNewDetector(sd);
-    SetSensitiveDetector(fakeDetectorLV, sd);
+    if (G4SDManager::GetSDMpointer()->FindSensitiveDetector("FakeCaloDetector", 0)) delete G4SDManager::GetSDMpointer()->FindSensitiveDetector("FakeCaloDetector");
+    G4SDManager* caloSDMan = G4SDManager::GetSDMpointer();
+    MyPositronDetector* caloSD = new MyPositronDetector("FakeCaloDetector", "FakeCaloDetectorCollection", this);
+    caloSDMan->AddNewDetector(caloSD);
+    SetSensitiveDetector(fakeCaloDetectorLV, caloSD);
     G4cout << "Sensitive Detector created" << G4endl;
+
+    if (G4SDManager::GetSDMpointer()->FindSensitiveDetector("FakePosDetector", 0)) delete G4SDManager::GetSDMpointer()->FindSensitiveDetector("FakePosDetector");
+    G4SDManager* posSDMan = G4SDManager::GetSDMpointer();
+    MyPositronDetector* posSD = new MyPositronDetector("FakePosDetector", "FakePosDetectorCollection", this);
+    posSDMan->AddNewDetector(posSD);
+    SetSensitiveDetector(fakePosDetectorLV, posSD);
+    G4cout << "Sensitive Detector created" << G4endl;
+
 
 
     G4SDManager::GetSDMpointer()->SetVerboseLevel(1);

--- a/simulation/DetectorConstruction.hh
+++ b/simulation/DetectorConstruction.hh
@@ -47,7 +47,8 @@ private:
     G4LogicalVolume *calorimeterLV;
     G4LogicalVolume *positronDetectorLV;
 
-    G4LogicalVolume *fakeDetectorLV;
+    G4LogicalVolume *fakeCaloDetectorLV;
+    G4LogicalVolume *fakePosDetectorLV;
 
     G4MagneticField *magField;
     G4FieldManager *fieldMgr;

--- a/simulation/EventAction.cc
+++ b/simulation/EventAction.cc
@@ -70,7 +70,6 @@ void EventAction::EndOfEventAction(const G4Event* event) {
     auto absoTrackLength = GetSum(GetHitsCollection(fAbsoTrackLengthHCID, event));
     auto gapTrackLength = GetSum(GetHitsCollection(fGapTrackLengthHCID, event));
 
-
     // Retrieve primary vertex
     G4PrimaryVertex* primaryVertex = event->GetPrimaryVertex(0);
 
@@ -78,14 +77,12 @@ void EventAction::EndOfEventAction(const G4Event* event) {
     G4PrimaryParticle* primaryParticle = primaryVertex->GetPrimary();
     G4String particleName = primaryParticle->GetParticleDefinition()->GetParticleName();
 
-    G4cout << "\n\n\n\n PRINTING PARTICLE NAME HERE: " << particleName << "\n\n\n\n" << G4endl; // This is the name of the particles that was generated!!!!!!!
 
     // get analysis manager
     auto *man = G4RootAnalysisManager::Instance();
 
     auto eventID = event->GetEventID();
 
-    G4cout << "\n\n\n PRINTING EVENTID HERE: \n\n " << eventID << "\n\n PRINTING EVENTID HERE \n\n\n" << G4endl;
 
     G4cout << "The energy deposit in calodetector (EventAction) is: " << absoEdep << G4endl;
     G4cout << "The energy deposit in positrondetector (EventAction) is: " << absoEdep << G4endl;
@@ -97,6 +94,10 @@ void EventAction::EndOfEventAction(const G4Event* event) {
     man->FillNtupleDColumn(3, 4, gapTrackLength);
 
     man->AddNtupleRow(3);
+
+    man->FillNtupleIColumn(4, 0, eventID);
+
+    man->AddNtupleRow(4);
 
     //print per event (modulo n)
     //auto eventID = event->GetEventID();

--- a/simulation/EventAction.cc
+++ b/simulation/EventAction.cc
@@ -7,6 +7,9 @@
 #include "G4HCofThisEvent.hh"
 #include "G4UnitsTable.hh"
 
+#include "G4PrimaryVertex.hh"
+#include "G4PrimaryParticle.hh"
+
 #include "Randomize.hh"
 #include <iomanip>
 
@@ -66,6 +69,16 @@ void EventAction::EndOfEventAction(const G4Event* event) {
     auto gapEdep = GetSum(GetHitsCollection(fGapEdepHCID, event));
     auto absoTrackLength = GetSum(GetHitsCollection(fAbsoTrackLengthHCID, event));
     auto gapTrackLength = GetSum(GetHitsCollection(fGapTrackLengthHCID, event));
+
+
+    // Retrieve primary vertex
+    G4PrimaryVertex* primaryVertex = event->GetPrimaryVertex(0);
+
+    // Acces primary particles generated in this vertex
+    G4PrimaryParticle* primaryParticle = primaryVertex->GetPrimary();
+    G4String particleName = primaryParticle->GetParticleDefinition()->GetParticleName();
+
+    G4cout << "\n\n\n\n PRINTING PARTICLE NAME HERE: " << particleName << "\n\n\n\n" << G4endl; // This is the name of the particles that was generated!!!!!!!
 
     // get analysis manager
     auto *man = G4RootAnalysisManager::Instance();

--- a/simulation/Hits.cc
+++ b/simulation/Hits.cc
@@ -2,8 +2,20 @@
 
 G4ThreadLocal G4Allocator<Hits>* HitAllocator = 0;
 
-Hits::Hits(): G4VHit(), numberOfPositrons(0), energyDeposit(0), eventID(0)
+Hits::Hits(): G4VHit(), numberOfPhotons(0), numberOfPositrons(0), energyDeposit(0), eventID(0)
 {}
 
 Hits::~Hits()
 {}
+
+void Hits::Print() {
+    G4cout
+        << "Current event is: "
+        << eventID
+        << "\nNumber Of Photons in this event: "
+        <<  numberOfPhotons
+        << "\nNumber Of Positrons in this event: "
+        << numberOfPositrons
+        << "\n"
+        << G4endl;
+}

--- a/simulation/Hits.cc
+++ b/simulation/Hits.cc
@@ -10,12 +10,24 @@ Hits::~Hits()
 
 void Hits::Print() {
     G4cout
-        << "Current event is: "
+        << "Current detector is: "
         << eventID
         << "\nNumber Of Photons in this event: "
-        <<  numberOfPhotons
+        << numberOfPhotons
         << "\nNumber Of Positrons in this event: "
         << numberOfPositrons
         << "\n"
         << G4endl;
+}
+
+G4int Hits::GetNumberOfPhotons() {
+    return numberOfPhotons;
+}
+
+G4int Hits::GetNumberOfPositrons() {
+    return numberOfPositrons;
+}
+
+G4int Hits::GetNumberOfEvent() {
+    return eventID;
 }

--- a/simulation/Hits.hh
+++ b/simulation/Hits.hh
@@ -30,9 +30,10 @@ public:
     inline void AddNumberOfPositrons() {numberOfPositrons += 1;}
     inline void AddEventID() { eventID += 1; }
     inline double GetEnergyDeposit() {return energyDeposit;}
-    inline int GetNumberOfPhotons() {return numberOfPhotons;}
-    inline int GetNumberOfPositrons() {return numberOfPositrons;}
-    inline int GetNumberOfEvent() { return eventID; }
+    G4int GetNumberOfPhotons();
+    G4int GetNumberOfPositrons();
+    G4int GetNumberOfEvent();
+
 
 private:
     int numberOfPhotons;

--- a/simulation/Hits.hh
+++ b/simulation/Hits.hh
@@ -19,18 +19,23 @@ public:
     Hits();
     virtual ~Hits();
 
+    void Print() override;
+
     // Operators
     inline void *operator new(size_t);
     inline void operator delete(void*);
 
     inline void AddEnergyDeposit(double e) { energyDeposit += e; }
+    inline void AddNumberOfPhotons() {numberOfPhotons += 1;}
     inline void AddNumberOfPositrons() {numberOfPositrons += 1;}
     inline void AddEventID() { eventID += 1; }
     inline double GetEnergyDeposit() {return energyDeposit;}
+    inline int GetNumberOfPhotons() {return numberOfPhotons;}
     inline int GetNumberOfPositrons() {return numberOfPositrons;}
     inline int GetNumberOfEvent() { return eventID; }
 
 private:
+    int numberOfPhotons;
     int numberOfPositrons;
     double energyDeposit;
     int eventID;

--- a/simulation/RunAction.cc
+++ b/simulation/RunAction.cc
@@ -45,6 +45,14 @@ void MyRunAction::BeginOfRunAction(const G4Run*)
     man->CreateNtupleDColumn("posTrackLength");
 
     man->FinishNtuple(3);
+
+    // tuple that get number of particles in event:
+    man->CreateNtuple("ParticlesInEvent", "ParticlesInEvent");
+    man->CreateNtupleIColumn("EventID");
+    man->CreateNtupleDColumn("NumberOfPhotons");
+    man->CreateNtupleDColumn("NumberOfPositrons");
+
+    man->FinishNtuple(4);
 }
 
 void MyRunAction::EndOfRunAction(const G4Run*)

--- a/simulation/positrondetector.cc
+++ b/simulation/positrondetector.cc
@@ -109,22 +109,40 @@ G4bool MyPositronDetector::ProcessHits(G4Step *step, G4TouchableHistory *ROhist)
 
 void MyPositronDetector::EndOfEvent(G4HCofThisEvent* hce)
 {
-    /*
-    // Prints based on the particles detected
-    if (photonsDetected && positronsDetected) {
-        G4cout << "Event with both photons and positrons" << G4endl;
-    } else if (photonsDetected) {
-        G4cout << "Event with only photons" << G4endl;
-    } else if (positronsDetected) {
-        G4cout << "Event with only positrons" << G4endl;
-    } else {
-        G4cout << "Event with no photons or positrons" << G4endl;
-    }
-    */
+
+    G4int eventNumber = G4RunManager::GetRunManager()->GetCurrentEvent()->GetEventID();
+    auto *man = G4RootAnalysisManager::Instance();
 
     // Get the number of hits in the hitsCollection
     G4int nOfHits = hitsCollection->entries();
 
+
+    G4cout << "\n\nTHE EVENT NUMBER IS: " << eventNumber << "\n\n" <<G4endl;
+    G4cout << "\n\nNUMBER OF HITS IN THIS EVENT IS: " << nOfHits << "\n\n" <<G4endl;
+
+    G4int photonsCounter = 0; // counters for the number of photons and positrons in that event
+    G4int positronsCounter = 0;
+
     // loop through the hitsCollection
-    for (G4int i = 0; i < nOfHits; i++) (*hitsCollection)[i]->Print();
+    for (G4int i = 0; i < nOfHits; i++) {
+        //(*hitsCollection)[i]->Print();
+
+        G4int hitNum = (*hitsCollection)[i]->GetNumberOfEvent();
+        G4int numberOfPhotons = (*hitsCollection)[i]->GetNumberOfPhotons();
+        G4int numberOfPositrons = (*hitsCollection)[i]->GetNumberOfPositrons();
+
+        if (hitNum == 0) {
+            photonsCounter = photonsCounter + 1; // increments the counter for each photon found in a hit
+        }
+        if (hitNum == 1) {
+            positronsCounter = positronsCounter + 1; // increments the counter for each positron found in a hit
+        }
+        //man->AddNtupleRow(4);
+    }
+    if (photonsCounter != 0) {
+        man->FillNtupleDColumn(4, 1, photonsCounter);
+    }
+    if (positronsCounter !=0 ) {
+        man->FillNtupleDColumn(4, 2, positronsCounter);
+    }
 }

--- a/simulation/positrondetector.cc
+++ b/simulation/positrondetector.cc
@@ -50,26 +50,36 @@ G4bool MyPositronDetector::ProcessHits(G4Step *step, G4TouchableHistory *ROhist)
     G4StepPoint *preStepPoint = step->GetPreStepPoint();
     G4StepPoint *postStepPoint = step->GetPostStepPoint();
 
-    G4double positronEnergy = preStepPoint->GetTotalEnergy();
+    G4double particleEnergy = preStepPoint->GetTotalEnergy();
     G4ThreeVector posParticle = preStepPoint->GetPosition();
 
     G4ThreeVector detectorPos = G4ThreeVector(0, -1.25*m, 2.21*m);
     G4ThreeVector newPos = posParticle - detectorPos;
 
     G4cout << "Particle position in positrondetector is: " << newPos << G4endl;
-    G4cout << "Particle energy in positrondetector is: " << positronEnergy << G4endl;
+    G4cout << "Particle energy in positrondetector is: " << particleEnergy << G4endl;
 
     auto *man = G4RootAnalysisManager::Instance();
     //man->FillNtupleIColumn(1, 0, evt);
 
-    if (particle == G4Positron::Positron()) {
+    if (particle == G4Gamma::Gamma()) {
+        man->FillNtupleIColumn(0, 0, eventNumber);
+        man->FillNtupleDColumn(0, 1, particleEnergy);
+        man->FillNtupleDColumn(0, 2, posParticle[0]);
+        man->FillNtupleDColumn(0, 3, posParticle[1]);
+        //man->FillNtupleDColumn(0, 4, missMass);
 
-        man->FillNtupleDColumn(1, 1, positronEnergy);
+        man->AddNtupleRow(0);
+    }
+
+    if (particle == G4Positron::Positron()) {
+        man->FillNtupleIColumn(1, 0, eventNumber);
+        man->FillNtupleDColumn(1, 1, particleEnergy);
         man->FillNtupleDColumn(1, 2, newPos[0]);
         man->FillNtupleDColumn(1, 3, newPos[1]);
 
+        man->AddNtupleRow(1);
     }
-    man->AddNtupleRow(1);
 
     man->FillNtupleIColumn(2, 1, eventNumber);
     man->AddNtupleRow(2);

--- a/simulation/positrondetector.cc
+++ b/simulation/positrondetector.cc
@@ -4,11 +4,17 @@ MyPositronDetector::MyPositronDetector(const G4String& name, const G4String& hit
 : G4VSensitiveDetector(name), hitsCollection(0), hcid(-1), det(_det) {
     collectionName.insert(hitsCollectionName);
     G4cout << "Creating Sensitive Detector named: " << name << G4endl;
+
+    photonsDetected = false;
+    positronsDetected = false;
 }
 
 MyPositronDetector::~MyPositronDetector() {}
 
 void MyPositronDetector::Initialize(G4HCofThisEvent* hce) {
+    photonsDetected = false;
+    positronsDetected = false;
+
     // Create hits collection
     hitsCollection = new HitsCollection(SensitiveDetectorName, collectionName[0]);
 
@@ -59,6 +65,15 @@ G4bool MyPositronDetector::ProcessHits(G4Step *step, G4TouchableHistory *ROhist)
     G4cout << "Particle position in positrondetector is: " << newPos << G4endl;
     G4cout << "Particle energy in positrondetector is: " << particleEnergy << G4endl;
 
+    // Check if the particle is a photon
+    if (particle == G4Gamma::Gamma()) {
+        photonsDetected = true;
+    }
+    // Check if the particle is a positron
+    else if (particle == G4Positron::Positron()) {
+        positronsDetected = true;
+    }
+
     auto *man = G4RootAnalysisManager::Instance();
     //man->FillNtupleIColumn(1, 0, evt);
 
@@ -88,4 +103,15 @@ G4bool MyPositronDetector::ProcessHits(G4Step *step, G4TouchableHistory *ROhist)
 }
 
 void MyPositronDetector::EndOfEvent(G4HCofThisEvent* hce)
-{}
+{
+    // Classify the event based on the particles detected
+    if (photonsDetected && positronsDetected) {
+        G4cout << "Event with both photons and positrons" << G4endl;
+    } else if (photonsDetected) {
+        G4cout << "Event with only photons" << G4endl;
+    } else if (positronsDetected) {
+        G4cout << "Event with only positrons" << G4endl;
+    } else {
+        G4cout << "Event with no photons or positrons" << G4endl;
+    }
+}

--- a/simulation/positrondetector.cc
+++ b/simulation/positrondetector.cc
@@ -4,11 +4,17 @@ MyPositronDetector::MyPositronDetector(const G4String& name, const G4String& hit
 : G4VSensitiveDetector(name), hitsCollection(0), hcid(-1), det(_det) {
     collectionName.insert(hitsCollectionName);
     G4cout << "Creating Sensitive Detector named: " << name << G4endl;
+
+    photonsDetected = false;
+    positronsDetected = false;
 }
 
 MyPositronDetector::~MyPositronDetector() {}
 
 void MyPositronDetector::Initialize(G4HCofThisEvent* hce) {
+    photonsDetected = false;
+    positronsDetected = false;
+
     // Create hits collection
     hitsCollection = new HitsCollection(SensitiveDetectorName, collectionName[0]);
 
@@ -40,9 +46,23 @@ G4bool MyPositronDetector::ProcessHits(G4Step *step, G4TouchableHistory *ROhist)
         }
     }
 
-    //Get positron when it is generated
-    if (particle == G4Positron::Positron() && step->IsFirstStepInVolume()) {
-        hit->AddNumberOfPositrons();
+    // Check if the particle is a photon
+    if (particle == G4Gamma::Gamma()) {
+        photonsDetected = true;
+
+        //Get photon when it is generated
+        if(step->IsFirstStepInVolume()) {
+            hit->AddNumberOfPhotons();
+        }
+    }
+    // Check if the particle is a positron
+    if (particle == G4Positron::Positron()) {
+        positronsDetected = true;
+
+        //Get positron when it is generated
+        if(step->IsFirstStepInVolume()) {
+            hit->AddNumberOfPositrons();
+        }
     }
 
     hitsCollection->insert(hit);
@@ -88,4 +108,23 @@ G4bool MyPositronDetector::ProcessHits(G4Step *step, G4TouchableHistory *ROhist)
 }
 
 void MyPositronDetector::EndOfEvent(G4HCofThisEvent* hce)
-{}
+{
+    /*
+    // Prints based on the particles detected
+    if (photonsDetected && positronsDetected) {
+        G4cout << "Event with both photons and positrons" << G4endl;
+    } else if (photonsDetected) {
+        G4cout << "Event with only photons" << G4endl;
+    } else if (positronsDetected) {
+        G4cout << "Event with only positrons" << G4endl;
+    } else {
+        G4cout << "Event with no photons or positrons" << G4endl;
+    }
+    */
+
+    // Get the number of hits in the hitsCollection
+    G4int nOfHits = hitsCollection->entries();
+
+    // loop through the hitsCollection
+    for (G4int i = 0; i < nOfHits; i++) (*hitsCollection)[i]->Print();
+}

--- a/simulation/positrondetector.hh
+++ b/simulation/positrondetector.hh
@@ -13,6 +13,9 @@
 #include "G4SDManager.hh"
 #include "G4Step.hh"
 
+#include "G4HCofThisEvent.hh"
+#include "G4Track.hh"
+
 #include "DetectorConstruction.hh"
 #include "Hits.hh"
 
@@ -34,6 +37,9 @@ public:
     void EndOfEvent(G4HCofThisEvent* hce);
 
 private:
+    G4bool photonsDetected;
+    G4bool positronsDetected;
+
     HitsCollection* hitsCollection;
     int hcid;
     int eventID;

--- a/utils/caloEdep.C
+++ b/utils/caloEdep.C
@@ -1,0 +1,30 @@
+void caloEdep() 
+{
+    TCanvas *c4 = new TCanvas();
+
+    TFile *input = new TFile("output.root", "read");
+	
+    TTree *tree = (TTree*)input->Get("EventAction");
+	
+    int PositronEventID;
+    double caloEdep, posEdep, caloTrackLength, posTrackLength;
+
+    tree->SetBranchAddress("caloEdep", &caloEdep);
+
+    int entries = tree->GetEntries();
+	
+    TH1F *hist = new TH1F("hist", "caloEdep", 200, 0, 0.01); //name, title, n_bins, range1, range2
+
+    for(int i = 0; i < entries; i++) {
+        tree->GetEntry(i);
+		
+	hist->Fill(caloEdep);
+    }
+	
+    hist->Draw();
+
+    c4->SaveAs("caloEdep.png");
+
+    input->Close();
+}
+

--- a/utils/photonTotalEnergy.C
+++ b/utils/photonTotalEnergy.C
@@ -1,0 +1,35 @@
+void photonTotalEnergy()
+{
+    TCanvas *c2 = new TCanvas("c2", "c2", 800, 800);
+
+    TFile *input = new TFile("output.root", "read");
+
+    TTree *tree = (TTree*)input->Get("PhotonHits");
+
+    int EventID; 
+    double PhotonEnergy, photonX, photonY;
+
+    tree->SetBranchAddress("PhotonEnergy", &PhotonEnergy);
+    tree->SetBranchAddress("EventID", &EventID);
+
+    int entries = tree->GetEntries();
+
+    //cout << entries << endl;
+
+    TH1F *hist = new TH1F("hist", "PhotonEnergy", 200, 0, 600); //name, title, n_bins, range1, range2
+
+    for(int i = 0; i < entries; i++) {
+        tree->GetEntry(i);
+
+	cout << PhotonEnergy << " " << EventID << endl;
+
+	hist->Fill(PhotonEnergy);
+    }
+
+    hist->Draw();
+
+    c2->SaveAs("photonHisto.png");
+
+    input->Close();
+}
+

--- a/utils/photonTotalEnergy.C
+++ b/utils/photonTotalEnergy.C
@@ -1,6 +1,6 @@
 void photonTotalEnergy()
 {
-    TCanvas *c2 = new TCanvas("c2", "c2", 800, 800);
+    TCanvas *c2 = new TCanvas("c2", "c2");
 
     TFile *input = new TFile("output.root", "read");
 

--- a/utils/positronEdep.C
+++ b/utils/positronEdep.C
@@ -1,0 +1,30 @@
+void positronEdep() 
+{
+    TCanvas *c3 = new TCanvas();
+
+    TFile *input = new TFile("output.root", "read");
+	
+    TTree *tree = (TTree*)input->Get("EventAction");
+	
+    int PositronEventID;
+    double caloEdep, posEdep, caloTrackLength, posTrackLength;
+
+    tree->SetBranchAddress("posEdep", &posEdep);
+	
+    int entries = tree->GetEntries();
+	
+    TH1F *hist = new TH1F("hist", "posEdep", 200, 0, 2); //name, title, n_bins, range1, range2
+    
+    for(int i = 0; i < entries; i++) {
+	tree->GetEntry(i);
+				
+	hist->Fill(posEdep);
+    }
+	
+    hist->Draw();
+
+    c3->SaveAs("positronEdep.png");
+
+    input->Close();
+}
+

--- a/utils/positronTotalEnergy.C
+++ b/utils/positronTotalEnergy.C
@@ -1,6 +1,6 @@
 void positronTotalEnergy()
 {
-    TCanvas *c1 = new TCanvas("c2", "c2", 800, 800);
+    TCanvas *c1 = new TCanvas("c2", "c2");
 
     TFile *input = new TFile("output.root", "read");
 

--- a/utils/positronTotalEnergy.C
+++ b/utils/positronTotalEnergy.C
@@ -1,0 +1,35 @@
+void positronTotalEnergy()
+{
+    TCanvas *c1 = new TCanvas("c2", "c2", 800, 800);
+
+    TFile *input = new TFile("output.root", "read");
+
+    TTree *tree = (TTree*)input->Get("PositronHits");
+
+    int EventID;
+    double PositronEnergy, positronx, positronY;
+
+    tree->SetBranchAddress("PositronEnergy", &PositronEnergy);
+    tree->SetBranchAddress("EventID", &EventID);
+
+    int entries = tree->GetEntries();
+
+    //cout << entries << endl;
+
+    TH1F *hist = new TH1F("hist", "PositronEnergy", 200, 549.5, 550); //name, title, n_bins, range1, range2
+
+    for(int i = 0; i < entries; i++) {
+	tree->GetEntry(i);
+
+	cout << PositronEnergy << " " << EventID << endl;
+
+	hist->Fill(PositronEnergy);
+    }
+
+    hist->Draw();
+
+    c1->SaveAs("positronHisto.png");
+
+    input->Close();
+}
+


### PR DESCRIPTION
Implemented functionality that registers the number of photons and positrons detected for each event.

Added utils folder with scripts for data analysis.

Updated .gitignore.

Updated readme.


Here are some of the plots obtained through the scripts, with 100000 events, firstly the total energy that the positrons and photons hit the detector respectively:
![image](https://github.com/GASP-UFRGS/DarkPhoton-LNLS/assets/78316565/995e7055-dc4a-4c25-aac1-376d510d9bf3)
![image](https://github.com/GASP-UFRGS/DarkPhoton-LNLS/assets/78316565/4dd888bf-0bc4-4a1f-90bb-0de5a7490a1f)

Now for the energy deposit of positrons and photons respectively:
![image](https://github.com/GASP-UFRGS/DarkPhoton-LNLS/assets/78316565/b53e73ef-2b35-4895-9807-120f994c08d6)
![image](https://github.com/GASP-UFRGS/DarkPhoton-LNLS/assets/78316565/322e716e-ed4c-4dab-a3fe-275c23f5c6c8)
All values for energy deposit are zero. Perhaps the particles don't lose much energy when interacting with the detectors?

Lastly there is a brief plot indicating the number of particles detected for event, with only 100 events
![image](https://github.com/GASP-UFRGS/DarkPhoton-LNLS/assets/78316565/f0ddb1d9-e170-456d-9df1-fc0c94cb64ae)
![image](https://github.com/GASP-UFRGS/DarkPhoton-LNLS/assets/78316565/b8caebc8-5d73-4d3d-a47d-b7f214c763b2)
All values for the particles detected are one, which means that in a single event, it was never detected more than one photon or positron.